### PR TITLE
feat: add --invalidate-cache for PostToolUse hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ Override TTL with environment variable:
 }
 ```
 
+### Auto-invalidation hook
+
+Add a PostToolUse hook to auto-invalidate the cache when `gh pr create/merge/close` is executed:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y sai-kaneko-31/cc-statusline --invalidate-cache"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## Acknowledgments
 
 Inspired by [him0/claude-code-statusline](https://github.com/him0/claude-code-statusline) and [this article](https://zenn.dev/him0/articles/f1215cea2c715e).

--- a/index.js
+++ b/index.js
@@ -7,6 +7,34 @@ const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 
+// ── --invalidate-cache mode (PostToolUse hook) ──
+if (process.argv.includes('--invalidate-cache')) {
+  try {
+    const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+    const cmd = (input.tool_input && input.tool_input.command) || '';
+    if (!/gh\s+pr\s+(create|merge|close)/.test(cmd)) process.exit(0);
+
+    const homeDir = os.homedir();
+    const cacheDir = path.join(homeDir, '.claude', 'cache');
+    if (!fs.existsSync(cacheDir)) process.exit(0);
+
+    const branch = execSync('git symbolic-ref --short HEAD', {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const toplevel = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const repoId = crypto.createHash('md5').update(toplevel).digest('hex').slice(0, 8);
+    const cacheFile = path.join(cacheDir, `pr-${repoId}-${branch.replace(/\//g, '_')}.json`);
+    fs.rmSync(cacheFile, { force: true });
+  } catch {}
+  process.exit(0);
+}
+
 // Read JSON from stdin
 let data;
 try {


### PR DESCRIPTION
## Summary
- `--invalidate-cache` フラグ追加: `gh pr create/merge/close` 検出時に PR キャッシュを削除
- README に PostToolUse hook の設定例を追記

## Usage
```json
{
  "hooks": {
    "PostToolUse": [{
      "matcher": "Bash",
      "hooks": [{
        "type": "command",
        "command": "npx -y sai-kaneko-31/cc-statusline --invalidate-cache"
      }]
    }]
  }
}
```

## Test plan
- [x] `gh pr create` コマンドでキャッシュ削除を確認
- [x] 非マッチコマンドでキャッシュ保持を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)