### PR TITLE
docs: add colleague comments to README and update CLAUDE.md gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"context_wi
 
 # Test with colleague comment (requires cached comment)
 echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"context_window\":{\"used_percentage\":70}}" | node index.js --colleague-instruction 'Be friendly'
+
+# Manual test of claude -p (must unset env vars to avoid recursion inside Claude Code)
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TASKS claude -p 'test prompt' --model haiku
 ```
 
 ## Testing
@@ -32,6 +35,7 @@ echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"context_wi
 - Framework: `node:test` (Node.js built-in)
 - Test file: `test/statusline.test.js`
 - CI: GitHub Actions with Node.js 18/20/22 matrix
+- `node --test` output may not display in Claude Code Bash tool; redirect to file (`1>/tmp/test.txt 2>&1`) then Read
 
 ## stdin JSON Fields
 
@@ -87,4 +91,4 @@ echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"context_wi
 - If `claude` CLI is not installed or not authenticated, colleague comments are silently skipped
 - The `--generate-comment` background process must unset `CLAUDECODE` and related env vars to avoid recursion
 - Tests use `process.execPath` (not `'node'`) for portability; `claude` CLI tests are skipped when not authenticated
-- GitHub repo rules require PRs to merge into main (direct push rejected)
+- GitHub repo rules require PRs to merge into main (direct push rejected); merge commits disabled, use `gh pr merge --squash`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) statusline comma
 | HP bar | Context window remaining until auto-compact (85%), color-coded |
 | Git stats | Branch, ahead/behind, insertions/deletions |
 | 3-column alignment | Path/model, branch+PR/HP bar, stats/time |
+| Colleague comments | Optional LLM-generated contextual comments (3rd line) |
 
 ## Requirements
 
@@ -95,6 +96,46 @@ Add a PostToolUse hook to auto-invalidate the cache when `gh pr create/merge/clo
   }
 }
 ```
+
+## Colleague comments (optional)
+
+LLM-generated contextual comments displayed as an optional 3rd line. Requires [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude`) installed and authenticated.
+
+Enable by adding `--colleague-instruction` to the command:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "npx -y sai-kaneko-31/cc-statusline --colleague-instruction 'Your persona instruction here'"
+  }
+}
+```
+
+Example — an enthusiastic お嬢様 colleague:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "npx -y sai-kaneko-31/cc-statusline --colleague-instruction 'テンションが高いお嬢様。'"
+  }
+}
+```
+
+```
+ ~/git/my-project   main   +121/-43
+ Opus 4.6            [████████░░]53%    2026/02/23 14:30:00
+ あら、README.mdをお仕上げですか～！本当にお見事な整理力ですわね～！
+```
+
+Comments are cached at `~/.claude/cache/statusline-comment-<repo-hash>.json` (5 min TTL) and generated in the background via `claude -p`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `STATUSLINE_COMMENT_MODEL` | `haiku` | Model for comment generation |
+| `STATUSLINE_COMMENT_TTL_MS` | `300000` (5 min) | Comment cache TTL |
+| `STATUSLINE_COMMENT_HISTORY_SIZE` | `5` | Previous comments tracked for dedup |
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary
- README に colleague comments セクションを追加（設定例、お嬢様ペルソナの出力サンプル、環境変数テーブル）
- CLAUDE.md に squash merge の注記、`node --test` 出力の回避策、`claude -p` 手動テストコマンドを追加

## Test plan
- [x] ドキュメントのみの変更、コード変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)