### PR TITLE
fix: rename HP to context window in comment prompt and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 |-------|------|----------|-------------|
 | `cwd` | string | Yes | Working directory (used for git info) |
 | `model.display_name` | string | No | Model name (icon changes for "Opus"/"Sonnet"/"Haiku") |
-| `context_window.used_percentage` | number | No | Context usage percentage (used for HP bar) |
+| `context_window.used_percentage` | number | No | Context usage percentage (used for context window bar) |
 | `cost.total_cost_usd` | number | No | Session total cost in USD (used in colleague comments) |
 | `cost.total_duration_ms` | number | No | Session total duration in ms (used in colleague comments) |
 | `cost.total_lines_added` | number | No | Total lines added in session (used in colleague comments) |
@@ -54,14 +54,14 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 
 - PR info cached at `~/.claude/cache/pr-<repoHash>-<branch>.json` (TTL: 5 min, override with `STATUSLINE_PR_CACHE_TTL_MS`)
 - repoHash is first 8 chars of MD5 of `git rev-parse --show-toplevel`
-- HP bar converts used_percentage to "remaining until 85% (auto-compact threshold)"
+- Context window bar converts used_percentage to "remaining until 85% (auto-compact threshold)"
 - OSC8 hyperlinks use BEL (`\x07`) terminator
 - All git commands have `timeout: 3000ms`; `gh` commands use `timeout 2`
 - `--invalidate-cache` mode: deletes cache file when `gh pr create/merge/close` is detected in PostToolUse hook input
 - Comment cache at `~/.claude/cache/statusline-comment-<hash>.json` where hash = MD5(toplevel + session_id)[:8] (TTL: 5 min, override with `STATUSLINE_COMMENT_TTL_MS`)
 - Comment cache format: `{ comment: "text", history: ["prev1", "prev2", ...] }` — history keeps last N comments for dedup
 - Comment prompt: instruction first (persona adherence), dynamic context (empty fields omitted), changedFiles max 5
-- Comment prompt priority: changed files > branch > time > duration/cost; HP only shown if <15%
+- Comment prompt priority: changed files > branch > time > duration/cost; context window remaining only shown if <15%
 - Comment dedup uses positive instruction ("say something different") instead of negative ("DO NOT repeat")
 - `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model>` to generate context-aware comments
 - `--colleague-instruction` flag enables the optional 3rd line with LLM-generated colleague comments

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) statusline command with Nerd Font icons, clickable PR links, and a context window HP bar.
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) statusline command with Nerd Font icons, clickable PR links, and a context window bar.
 
 ```
  ~/git/my-project   feature/auth #42   ↑2 +15/-3
@@ -13,9 +13,9 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) statusline comma
 |---------|-------------|
 | Nerd Font icons | Model-specific icons (Opus , Sonnet , Haiku ) |
 | OSC8 PR links | Ctrl+Click to open PR in browser (BEL terminator) |
-| HP bar | Context window remaining until auto-compact (85%), color-coded |
+| Context window bar | Context window remaining until auto-compact (85%), color-coded |
 | Git stats | Branch, ahead/behind, insertions/deletions |
-| 3-column alignment | Path/model, branch+PR/HP bar, stats/time |
+| 3-column alignment | Path/model, branch+PR/context window bar, stats/time |
 | Colleague comments | Optional LLM-generated contextual comments (3rd line) |
 
 ## Requirements
@@ -50,10 +50,10 @@ Line 2:  <model>         <heart> [<bar>]<remaining>%              <clock> <time>
 | Column | Line 1 | Line 2 |
 |--------|--------|--------|
 | col1 | Working directory (`~` substituted) | Model name with icon |
-| col2 | Branch + clickable PR number | HP bar (remaining context %) |
+| col2 | Branch + clickable PR number | Context window bar (remaining %) |
 | col3 | Ahead/behind + diff stats | Current time |
 
-### HP bar color
+### Context window bar color
 
 | Remaining | Color | Meaning |
 |-----------|-------|---------|

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ if (generateCommentIdx !== -1) {
     if (durationMin != null) ctxParts.push(`duration=${durationMin}min`);
     if (costUsd != null) ctxParts.push(`cost=$${costUsd.toFixed(2)}`);
     if (linesAdded || linesRemoved) ctxParts.push(`lines +${linesAdded || 0}/-${linesRemoved || 0}`);
-    if (hpRemaining != null && hpRemaining <= 15) ctxParts.push(`HP=${hpRemaining}% (low!)`);
+    if (hpRemaining != null && hpRemaining <= 15) ctxParts.push(`context_window_remaining=${hpRemaining}% (low!)`);
 
     const prompt = [
       instruction || 'Be friendly and supportive.',


### PR DESCRIPTION
## Summary
- Renamed `HP` to `context_window_remaining` in the LLM comment prompt to prevent Haiku from misinterpreting it as "battery"
- Updated all references from "HP bar" to "context window bar" in CLAUDE.md and README.md for consistency

## Test plan
- [x] `npm test` — all 16 tests pass
- [ ] Verify colleague comments no longer reference "battery" when context window is low

🤖 Generated with [Claude Code](https://claude.com/claude-code)