### PR TITLE
fix: rename HP to context window in package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-statusline",
   "version": "1.0.0",
-  "description": "Claude Code statusline with Nerd Font icons, OSC8 PR links, and HP bar",
+  "description": "Claude Code statusline with Nerd Font icons, OSC8 PR links, and context window bar",
   "main": "index.js",
   "bin": {
     "cc-statusline": "./index.js"


### PR DESCRIPTION
## Summary
- Follow-up to #17 — updated `package.json` description from "HP bar" to "context window bar"

## Test plan
- [x] No functional change, description field only

🤖 Generated with [Claude Code](https://claude.com/claude-code)