### PR TITLE
feat: add STATUSLINE_THEME env var for color scheme switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 | `STATUSLINE_COMMENT_MODEL` | `haiku` | Model alias for `claude -p --model` |
 | `STATUSLINE_COMMENT_TTL_MS` | `300000` (5 min) | Colleague comment cache TTL |
 | `STATUSLINE_COMMENT_HISTORY_SIZE` | `5` | Number of previous comments to track for dedup |
+| `STATUSLINE_THEME` | `default` | Color theme: `default`, `light`, `minimal`, `dracula` |
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ Comments are cached at `~/.claude/cache/statusline-comment-<repo-hash>.json` (5 
 | `STATUSLINE_COMMENT_MODEL` | `haiku` | Model for comment generation |
 | `STATUSLINE_COMMENT_TTL_MS` | `300000` (5 min) | Comment cache TTL |
 | `STATUSLINE_COMMENT_HISTORY_SIZE` | `5` | Previous comments tracked for dedup |
+| `STATUSLINE_THEME` | `default` | Color theme: `default`, `light`, `minimal`, `dracula` |
+
+## Themes
+
+Switch color schemes via `STATUSLINE_THEME` environment variable:
+
+| Theme | Description |
+|-------|-------------|
+| `default` | Bold ANSI colors (original) |
+| `light` | Non-bold colors + bright black dim — optimized for light backgrounds |
+| `minimal` | White/gray with red danger bar only |
+| `dracula` | 256-color palette (purple model, orange warning, muted dim) |
+
+```json
+{
+  "env": {
+    "STATUSLINE_THEME": "dracula"
+  }
+}
+```
+
+Unknown theme names fall back to `default`.
 
 ## Acknowledgments
 

--- a/index.js
+++ b/index.js
@@ -128,13 +128,62 @@ if (colleagueIdx !== -1) {
 
 // ANSI color codes
 const RESET = '\x1b[0m';
-const BOLD_CYAN = '\x1b[1;36m';
-const BOLD_PURPLE = '\x1b[1;35m';
-const BOLD_YELLOW = '\x1b[1;33m';
-const BOLD_GREEN = '\x1b[1;32m';
-const BOLD_RED = '\x1b[1;31m';
-const DIM_WHITE = '\x1b[2;37m';
-const BOLD_BLUE = '\x1b[1;34m';
+const THEMES = {
+  default: {
+    folder: '\x1b[1;36m',
+    branch: '\x1b[1;35m',
+    aheadBehind: '\x1b[1;33m',
+    added: '\x1b[1;32m',
+    deleted: '\x1b[1;31m',
+    model: '\x1b[1;34m',
+    barSafe: '\x1b[1;32m',
+    barWarning: '\x1b[1;33m',
+    barDanger: '\x1b[1;31m',
+    dim: '\x1b[2;37m',
+    clock: '\x1b[37m',
+  },
+  light: {
+    folder: '\x1b[36m',
+    branch: '\x1b[35m',
+    aheadBehind: '\x1b[33m',
+    added: '\x1b[32m',
+    deleted: '\x1b[31m',
+    model: '\x1b[34m',
+    barSafe: '\x1b[32m',
+    barWarning: '\x1b[33m',
+    barDanger: '\x1b[31m',
+    dim: '\x1b[90m',
+    clock: '\x1b[37m',
+  },
+  minimal: {
+    folder: '\x1b[37m',
+    branch: '\x1b[37m',
+    aheadBehind: '\x1b[37m',
+    added: '\x1b[37m',
+    deleted: '\x1b[37m',
+    model: '\x1b[37m',
+    barSafe: '\x1b[37m',
+    barWarning: '\x1b[37m',
+    barDanger: '\x1b[1;31m',
+    dim: '\x1b[90m',
+    clock: '\x1b[37m',
+  },
+  dracula: {
+    folder: '\x1b[1;36m',
+    branch: '\x1b[1;35m',
+    aheadBehind: '\x1b[1;33m',
+    added: '\x1b[1;32m',
+    deleted: '\x1b[1;31m',
+    model: '\x1b[38;5;141m',
+    barSafe: '\x1b[1;32m',
+    barWarning: '\x1b[38;5;215m',
+    barDanger: '\x1b[1;31m',
+    dim: '\x1b[38;5;61m',
+    clock: '\x1b[37m',
+  },
+};
+const themeName = (process.env.STATUSLINE_THEME || 'default').toLowerCase();
+const T = THEMES[themeName] || THEMES.default;
 
 // Nerd Font icons
 const ICON_FOLDER = '\uF07C';   //  folder-open
@@ -284,31 +333,31 @@ const ctxVisibleLen = 15; // [██████████]XX%
 const col2Len = Math.max(branchVisible.length, ctxVisibleLen);
 
 // ── Line 1: path + branch+PR + git stats ──
-let line1 = `${BOLD_CYAN}${ICON_FOLDER} ${padEnd(displayDir, col1Len)}${RESET}`;
+let line1 = `${T.folder}${ICON_FOLDER} ${padEnd(displayDir, col1Len)}${RESET}`;
 
 if (gitBranch) {
   const branchPad = col2Len - branchVisible.length;
   const padding = branchPad > 0 ? ' '.repeat(branchPad) : '';
   if (prNum) {
     // Branch name + OSC8 clickable PR link
-    line1 += `${COL_SEP}${BOLD_PURPLE}${ICON_BRANCH} ${gitBranch}${RESET} ${DIM_WHITE}${osc8(`#${prNum}`, prUrl)}${RESET}${padding}`;
+    line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${gitBranch}${RESET} ${T.dim}${osc8(`#${prNum}`, prUrl)}${RESET}${padding}`;
   } else {
-    line1 += `${COL_SEP}${BOLD_PURPLE}${ICON_BRANCH} ${padEnd(gitBranch, col2Len)}${RESET}`;
+    line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${padEnd(gitBranch, col2Len)}${RESET}`;
   }
 }
 
 if (gitAheadBehind) {
-  line1 += `${COL_SEP}${BOLD_YELLOW}${ICON_ROCKET} ${gitAheadBehind}${RESET}`;
+  line1 += `${COL_SEP}${T.aheadBehind}${ICON_ROCKET} ${gitAheadBehind}${RESET}`;
 } else {
-  line1 += `${COL_SEP}${DIM_WHITE}${ICON_ROCKET} -${RESET}`;
+  line1 += `${COL_SEP}${T.dim}${ICON_ROCKET} -${RESET}`;
 }
 
 const addedStr = gitAdded || '0';
 const deletedStr = gitDeleted || '0';
 if (parseInt(addedStr) > 0 || parseInt(deletedStr) > 0) {
-  line1 += ` ${BOLD_GREEN}+${addedStr}${RESET}/${BOLD_RED}-${deletedStr}${RESET}`;
+  line1 += ` ${T.added}+${addedStr}${RESET}/${T.deleted}-${deletedStr}${RESET}`;
 } else {
-  line1 += ` ${DIM_WHITE}-/-${RESET}`;
+  line1 += ` ${T.dim}-/-${RESET}`;
 }
 
 // ── Line 2: model + HP bar + time ──
@@ -318,7 +367,7 @@ else if (model.includes('Sonnet')) modelIcon = ICON_SONNET;
 else if (model.includes('Haiku')) modelIcon = ICON_HAIKU;
 else modelIcon = ICON_SONNET;
 
-let line2 = `${BOLD_BLUE}${modelIcon} ${padEnd(model, col1Len)}${RESET}`;
+let line2 = `${T.model}${modelIcon} ${padEnd(model, col1Len)}${RESET}`;
 
 let remaining = null;
 if (usedPct != null && usedPct !== '') {
@@ -332,20 +381,20 @@ if (usedPct != null && usedPct !== '') {
   const barEmpty = empty > 0 ? '░'.repeat(empty) : '';
 
   let barColor;
-  if (remaining <= 15) barColor = BOLD_RED;
-  else if (remaining <= 40) barColor = BOLD_YELLOW;
-  else barColor = BOLD_GREEN;
+  if (remaining <= 15) barColor = T.barDanger;
+  else if (remaining <= 40) barColor = T.barWarning;
+  else barColor = T.barSafe;
 
   const ctxTextLen = 10 + 2 + String(remaining).length + 1; // bars + [] + digits + %
   const ctxPad = col2Len - ctxTextLen;
   const ctxPadding = ctxPad > 0 ? ' '.repeat(ctxPad) : '';
 
-  line2 += `${COL_SEP}${barColor}${ICON_HEART} [${barFilled}${DIM_WHITE}${barEmpty}${barColor}]${remaining}%${ctxPadding}${RESET}`;
+  line2 += `${COL_SEP}${barColor}${ICON_HEART} [${barFilled}${T.dim}${barEmpty}${barColor}]${remaining}%${ctxPadding}${RESET}`;
 } else {
-  line2 += `${COL_SEP}${DIM_WHITE}${ICON_HEART} ${' '.repeat(col2Len)}${RESET}`;
+  line2 += `${COL_SEP}${T.dim}${ICON_HEART} ${' '.repeat(col2Len)}${RESET}`;
 }
 
-line2 += `${COL_SEP}\x1b[37m${ICON_CLOCK} ${currentTime}${RESET}`;
+line2 += `${COL_SEP}${T.clock}${ICON_CLOCK} ${currentTime}${RESET}`;
 
 // ── Colleague comment (optional 3rd line) ──
 let cachedComment = null;
@@ -394,6 +443,6 @@ if (colleagueInstruction !== null) {
 
 let output = `${line1}\n${line2}`;
 if (cachedComment) {
-  output += `\n${DIM_WHITE}${ICON_COMMENT} ${cachedComment}${RESET}`;
+  output += `\n${T.dim}${ICON_COMMENT} ${cachedComment}${RESET}`;
 }
 process.stdout.write(output);

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -235,3 +235,30 @@ describe('colleague comments', () => {
     }
   });
 });
+
+describe('themes', () => {
+  const stdinData = {
+    cwd: '/tmp',
+    model: { display_name: 'Opus 4.6' },
+    context_window: { used_percentage: 30 },
+  };
+
+  it('STATUSLINE_THEME=light uses non-bold colors', () => {
+    const result = runWithArgs(stdinData, [], { env: { ...process.env, STATUSLINE_THEME: 'light' } });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\x1b[36m'), 'should contain non-bold cyan for folder');
+    assert.ok(!result.stdout.includes('\x1b[1;36m'), 'should not contain bold cyan');
+  });
+
+  it('unknown theme name falls back to default', () => {
+    const result = runWithArgs(stdinData, [], { env: { ...process.env, STATUSLINE_THEME: 'nonexistent' } });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\x1b[1;36m'), 'should contain bold cyan (default folder color)');
+  });
+
+  it('STATUSLINE_THEME=dracula uses 256-color codes', () => {
+    const result = runWithArgs(stdinData, [], { env: { ...process.env, STATUSLINE_THEME: 'dracula' } });
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\x1b[38;5;141m'), 'should contain dracula 256-color purple for model');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `STATUSLINE_THEME` environment variable to switch between 4 preset color themes: `default`, `light`, `minimal`, `dracula`
- Replace 8 hardcoded ANSI color constants with 11 semantic color roles (`folder`, `branch`, `model`, `barSafe`, etc.) mapped through a `THEMES` object
- Unknown theme names gracefully fall back to `default`

## Test plan
- [x] All 19 tests pass (`npm test`)
- [x] ESLint clean (`npm run lint`)
- [x] Manual verification of all 4 themes
- [x] Fallback to default on unknown theme name
- [ ] CI passes on Node.js 18/20/22 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)