### PR TITLE
feat: show PR review status icons next to PR number

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 - Context window bar converts used_percentage to "remaining until 85% (auto-compact threshold)"
 - OSC8 hyperlinks use BEL (`\x07`) terminator
 - All git commands have `timeout: 3000ms`; `gh` commands use `timeout 2`
-- `--invalidate-cache` mode: deletes cache file when `gh pr create/merge/close` is detected in PostToolUse hook input
+- `--invalidate-cache` mode: deletes cache file when `gh pr create/merge/close/review` is detected in PostToolUse hook input
 - Comment cache at `~/.claude/cache/statusline-comment-<hash>.json` where hash = MD5(toplevel + session_id)[:8] (TTL: 5 min, override with `STATUSLINE_COMMENT_TTL_MS`)
 - Comment cache format: `{ comment: "text", history: ["prev1", "prev2", ...] }` — history keeps last N comments for dedup
 - Comment prompt: instruction first (persona adherence), dynamic context (empty fields omitted), changedFiles max 5
@@ -66,6 +66,8 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 - `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model>` to generate context-aware comments
 - `--colleague-instruction` flag enables the optional 3rd line with LLM-generated colleague comments
 - Requires `claude` CLI installed and authenticated; silently skips if unavailable
+- PR review status: `reviewDecision` from `gh pr view` mapped to icons (APPROVED→, CHANGES_REQUESTED→, REVIEW_REQUIRED→)
+- PR cache format: `{ number, url, reviewDecision }` — old caches without `reviewDecision` fall back to no icon
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) statusline command with Nerd Font icons, clickable PR links, and a context window bar.
 
 ```
- ~/git/my-project   feature/auth #42   ↑2 +15/-3
- Opus 4.6            [████████░░]53%    2026/02/23 14:30:00
+📂 ~/git/my-project  🔀 feature/auth #42 ✅  🚀 ↑2 +15/-3
+🔲 Opus 4.6          ❤️ [████████░░]53%     🕐 2026/02/23 14:30:00
 ```
 
 ## Features
 
 | Feature | Description |
 |---------|-------------|
-| Nerd Font icons | Model-specific icons (Opus , Sonnet , Haiku ) |
+| Nerd Font icons | Model-specific icons (Opus ``, Sonnet ``, Haiku ``) |
 | OSC8 PR links | Ctrl+Click to open PR in browser (BEL terminator) |
 | Context window bar | Context window remaining until auto-compact (85%), color-coded |
 | Git stats | Branch, ahead/behind, insertions/deletions |
@@ -40,9 +40,9 @@ Add to `~/.claude/settings.json`:
 ## Layout
 
 ```
-Line 1:  <path>          <branch> <#PR>   <rocket> <ahead/behind> <+added/-deleted>
-Line 2:  <model>         <heart> [<bar>]<remaining>%              <clock> <time>
-         ───col1───       ─────col2─────                           ───col3───
+Line 1: 📂 <path>         🔀 <branch> <#PR> <review>  🚀 <ahead/behind> <+added/-deleted>
+Line 2: 🔲 <model>        ❤️ [<bar>]<remaining>%       🕐 <time>
+         ───col1───        ─────col2─────                ───col3───
 ```
 
 ### Column details
@@ -50,8 +50,17 @@ Line 2:  <model>         <heart> [<bar>]<remaining>%              <clock> <time>
 | Column | Line 1 | Line 2 |
 |--------|--------|--------|
 | col1 | Working directory (`~` substituted) | Model name with icon |
-| col2 | Branch + clickable PR number | Context window bar (remaining %) |
+| col2 | Branch + clickable PR number + review status | Context window bar (remaining %) |
 | col3 | Ahead/behind + diff stats | Current time |
+
+### PR review status icons
+
+| reviewDecision | Icon | Color | Meaning |
+|----------------|------|-------|---------|
+| `APPROVED` | `` (check) | Green | PR approved |
+| `CHANGES_REQUESTED` | `` (close) | Red | Changes requested |
+| `REVIEW_REQUIRED` | `` (circle-o) | Yellow | Review pending |
+| (empty) | — | — | No icon shown |
 
 ### Context window bar color
 
@@ -77,7 +86,7 @@ Override TTL with environment variable:
 
 ### Auto-invalidation hook
 
-Add a PostToolUse hook to auto-invalidate the cache when `gh pr create/merge/close` is executed:
+Add a PostToolUse hook to auto-invalidate the cache when `gh pr create/merge/close/review` is executed:
 
 ```json
 {
@@ -124,9 +133,9 @@ Example — an enthusiastic お嬢様 colleague:
 ```
 
 ```
- ~/git/my-project   main   +121/-43
- Opus 4.6            [████████░░]53%    2026/02/23 14:30:00
- あら、README.mdをお仕上げですか～！本当にお見事な整理力ですわね～！
+📂 ~/git/my-project  🔀 main  🚀 +121/-43
+🔲 Opus 4.6          ❤️ [████████░░]53%     🕐 2026/02/23 14:30:00
+💬 あら、README.mdをお仕上げですか～！本当にお見事な整理力ですわね～！
 ```
 
 Comments are cached at `~/.claude/cache/statusline-comment-<repo-hash>.json` (5 min TTL) and generated in the background via `claude -p`.

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ if (process.argv.includes('--invalidate-cache')) {
   try {
     const input = JSON.parse(fs.readFileSync(0, 'utf8'));
     const cmd = (input.tool_input && input.tool_input.command) || '';
-    if (!/gh\s+pr\s+(create|merge|close)/.test(cmd)) process.exit(0);
+    if (!/gh\s+pr\s+(create|merge|close|review)/.test(cmd)) process.exit(0);
 
     const homeDir = os.homedir();
     const cacheDir = path.join(homeDir, '.claude', 'cache');
@@ -195,6 +195,9 @@ const ICON_HAIKU = '\uF0F4';    //  coffee
 const ICON_HEART = '\uF004';    //  heart
 const ICON_CLOCK = '\uF017';    //  clock
 const ICON_COMMENT = '\uF075';  //  comment
+const ICON_REVIEW_APPROVED = '\uF00C';   //  check
+const ICON_REVIEW_CHANGES = '\uF00D';    //  close
+const ICON_REVIEW_REQUIRED = '\uF10C';   //  circle-o
 
 const COL_SEP = '  ';
 
@@ -234,6 +237,7 @@ let gitAdded = '';
 let gitDeleted = '';
 let prNum = '';
 let prUrl = '';
+let prReviewDecision = '';
 
 if (exec(`git -C "${cwd}" rev-parse --git-dir`)) {
   gitBranch =
@@ -293,14 +297,14 @@ if (exec(`git -C "${cwd}" rev-parse --git-dir`)) {
     if (cached === null) {
       const remoteUrl = exec(`git -C "${cwd}" remote get-url origin`);
       const prJson = exec(
-        `timeout 2 gh pr view "${gitBranch}" --repo "${remoteUrl}" --json number,url,state`
+        `timeout 2 gh pr view "${gitBranch}" --repo "${remoteUrl}" --json number,url,state,reviewDecision`
       );
       if (prJson) {
         try {
           const pr = JSON.parse(prJson);
           cached =
             pr.state === 'OPEN'
-              ? { number: pr.number, url: pr.url }
+              ? { number: pr.number, url: pr.url, reviewDecision: pr.reviewDecision || '' }
               : { none: true };
         } catch {
           cached = { none: true };
@@ -316,6 +320,7 @@ if (exec(`git -C "${cwd}" rev-parse --git-dir`)) {
     if (cached && !cached.none) {
       prNum = String(cached.number);
       prUrl = cached.url;
+      prReviewDecision = cached.reviewDecision || '';
     }
   }
 }
@@ -327,8 +332,15 @@ const currentTime = `${now.getFullYear()}/${p2(now.getMonth() + 1)}/${p2(now.get
 
 // ── Column widths ──
 const col1Len = Math.max(displayDir.length, model.length);
+const REVIEW_MAP = {
+  APPROVED: { icon: ICON_REVIEW_APPROVED, color: T.added },
+  CHANGES_REQUESTED: { icon: ICON_REVIEW_CHANGES, color: T.deleted },
+  REVIEW_REQUIRED: { icon: ICON_REVIEW_REQUIRED, color: T.aheadBehind },
+};
+const reviewInfo = REVIEW_MAP[prReviewDecision] || null;
 const prText = prNum ? ` #${prNum}` : '';
-const branchVisible = gitBranch + prText;
+const reviewText = reviewInfo ? ` ${reviewInfo.icon}` : '';
+const branchVisible = gitBranch + prText + reviewText;
 const ctxVisibleLen = 15; // [██████████]XX%
 const col2Len = Math.max(branchVisible.length, ctxVisibleLen);
 
@@ -339,8 +351,9 @@ if (gitBranch) {
   const branchPad = col2Len - branchVisible.length;
   const padding = branchPad > 0 ? ' '.repeat(branchPad) : '';
   if (prNum) {
-    // Branch name + OSC8 clickable PR link
-    line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${gitBranch}${RESET} ${T.dim}${osc8(`#${prNum}`, prUrl)}${RESET}${padding}`;
+    // Branch name + OSC8 clickable PR link + review status
+    const reviewStr = reviewInfo ? ` ${reviewInfo.color}${reviewInfo.icon}${RESET}` : '';
+    line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${gitBranch}${RESET} ${T.dim}${osc8(`#${prNum}`, prUrl)}${RESET}${reviewStr}${padding}`;
   } else {
     line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${padEnd(gitBranch, col2Len)}${RESET}`;
   }

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -5,10 +5,13 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const crypto = require('crypto');
+
 const INDEX = path.join(__dirname, '..', 'index.js');
 const CACHE_DIR = path.join(os.homedir(), '.claude', 'cache');
 // /tmp is not a git repo, so cacheKey falls back to 'default'
 const COMMENT_CACHE = path.join(CACHE_DIR, 'statusline-comment-default.json');
+const REPO_CWD = path.join(__dirname, '..');
 
 const hasClaudeAuth = (() => {
   try {
@@ -49,6 +52,21 @@ function runWithArgs(input, args = [], options = {}) {
 
 function cleanCommentCache() {
   try { fs.rmSync(COMMENT_CACHE, { force: true }); } catch {}
+}
+
+function getPrCacheFile(cwd) {
+  const toplevel = execFileSync('git', ['-C', cwd, 'rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+  const branch = execFileSync('git', ['-C', cwd, 'symbolic-ref', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  const repoId = crypto.createHash('md5').update(toplevel).digest('hex').slice(0, 8);
+  const safeBranch = branch.replace(/\//g, '_');
+  return path.join(CACHE_DIR, `pr-${repoId}-${safeBranch}.json`);
+}
+
+function createPrCache(cwd, prData) {
+  const cacheFile = getPrCacheFile(cwd);
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  fs.writeFileSync(cacheFile, JSON.stringify(prData));
+  return cacheFile;
 }
 
 // Strip ANSI escape codes and OSC8 hyperlink sequences
@@ -232,6 +250,83 @@ describe('colleague comments', () => {
       assert.equal(lines.length, 2, 'should output 2 lines when cache is stale');
     } finally {
       cleanCommentCache();
+    }
+  });
+});
+
+describe('PR review status', () => {
+  const stdinData = {
+    cwd: REPO_CWD,
+    model: { display_name: 'Opus 4.6' },
+    context_window: { used_percentage: 30 },
+  };
+
+  let cacheFile;
+
+  function cleanPrCache() {
+    if (cacheFile) {
+      try { fs.rmSync(cacheFile, { force: true }); } catch {}
+    }
+  }
+
+  it('APPROVED shows check icon', () => {
+    cacheFile = createPrCache(REPO_CWD, { number: 99, url: 'https://github.com/test/repo/pull/99', reviewDecision: 'APPROVED' });
+    try {
+      const result = run(stdinData);
+      assert.equal(result.exitCode, 0);
+      assert.ok(result.stdout.includes('\uF00C'), 'should include check icon for APPROVED');
+      const plain = stripAnsi(result.stdout);
+      assert.ok(plain.includes('#99'), 'should include PR number');
+    } finally {
+      cleanPrCache();
+    }
+  });
+
+  it('CHANGES_REQUESTED shows close icon', () => {
+    cacheFile = createPrCache(REPO_CWD, { number: 100, url: 'https://github.com/test/repo/pull/100', reviewDecision: 'CHANGES_REQUESTED' });
+    try {
+      const result = run(stdinData);
+      assert.equal(result.exitCode, 0);
+      assert.ok(result.stdout.includes('\uF00D'), 'should include close icon for CHANGES_REQUESTED');
+    } finally {
+      cleanPrCache();
+    }
+  });
+
+  it('REVIEW_REQUIRED shows circle-o icon', () => {
+    cacheFile = createPrCache(REPO_CWD, { number: 101, url: 'https://github.com/test/repo/pull/101', reviewDecision: 'REVIEW_REQUIRED' });
+    try {
+      const result = run(stdinData);
+      assert.equal(result.exitCode, 0);
+      assert.ok(result.stdout.includes('\uF10C'), 'should include circle-o icon for REVIEW_REQUIRED');
+    } finally {
+      cleanPrCache();
+    }
+  });
+
+  it('empty reviewDecision shows no review icon', () => {
+    cacheFile = createPrCache(REPO_CWD, { number: 102, url: 'https://github.com/test/repo/pull/102', reviewDecision: '' });
+    try {
+      const result = run(stdinData);
+      assert.equal(result.exitCode, 0);
+      assert.ok(!result.stdout.includes('\uF00C'), 'should not include check icon');
+      assert.ok(!result.stdout.includes('\uF00D'), 'should not include close icon');
+      assert.ok(!result.stdout.includes('\uF10C'), 'should not include circle-o icon');
+    } finally {
+      cleanPrCache();
+    }
+  });
+
+  it('legacy cache without reviewDecision shows no review icon', () => {
+    cacheFile = createPrCache(REPO_CWD, { number: 103, url: 'https://github.com/test/repo/pull/103' });
+    try {
+      const result = run(stdinData);
+      assert.equal(result.exitCode, 0);
+      assert.ok(!result.stdout.includes('\uF00C'), 'should not include check icon');
+      assert.ok(!result.stdout.includes('\uF00D'), 'should not include close icon');
+      assert.ok(!result.stdout.includes('\uF10C'), 'should not include circle-o icon');
+    } finally {
+      cleanPrCache();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Display `reviewDecision` from `gh pr view` as colored Nerd Font icons after the PR number (APPROVED → ✅ green check, CHANGES_REQUESTED → ❌ red close, REVIEW_REQUIRED → 🟡 yellow circle)
- Invalidate PR cache on `gh pr review` in addition to create/merge/close
- Backwards-compatible with old cache format (no `reviewDecision` field → no icon)

## Test plan

- [x] 5 new tests for PR review status (APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, empty, legacy cache)
- [x] All 24 tests pass
- [x] ESLint passes
- [ ] Manual verification with real PR cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)