### PR TITLE
fix: exclude colleague comment sessions from resume list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 - Comment prompt: instruction first (persona adherence), dynamic context (empty fields omitted), changedFiles max 5
 - Comment prompt priority: changed files > branch > time > duration/cost; context window remaining only shown if <15%
 - Comment dedup uses positive instruction ("say something different") instead of negative ("DO NOT repeat")
-- `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model>` to generate context-aware comments
+- `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model> --no-session-persistence` to generate context-aware comments
 - `--colleague-instruction` flag enables the optional 3rd line with LLM-generated colleague comments
 - Requires `claude` CLI installed and authenticated; silently skips if unavailable
 - PR review status: `reviewDecision` from `gh pr view` mapped to icons (APPROVED→, CHANGES_REQUESTED→, REVIEW_REQUIRED→)

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ if (generateCommentIdx !== -1) {
     delete env.CLAUDE_CODE_ENTRYPOINT;
     delete env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
 
-    const raw = execFileSync('claude', ['-p', prompt, '--model', commentModel], {
+    const raw = execFileSync('claude', ['-p', prompt, '--model', commentModel, '--no-session-persistence'], {
       encoding: 'utf8',
       timeout: 30000,
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- Add `--no-session-persistence` to `claude -p` call so Haiku sessions used for colleague comment generation are not saved to disk and won't appear in resume session list

## Test plan
- [x] All 24 tests pass
- [ ] Verify `claude --resume` no longer shows Haiku comment sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)