### PR TITLE
fix: handle detached HEAD in PR review status tests

### DIFF
--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -56,7 +56,12 @@ function cleanCommentCache() {
 
 function getPrCacheFile(cwd) {
   const toplevel = execFileSync('git', ['-C', cwd, 'rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
-  const branch = execFileSync('git', ['-C', cwd, 'symbolic-ref', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  let branch;
+  try {
+    branch = execFileSync('git', ['-C', cwd, 'symbolic-ref', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    branch = execFileSync('git', ['-C', cwd, 'rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
+  }
   const repoId = crypto.createHash('md5').update(toplevel).digest('hex').slice(0, 8);
   const safeBranch = branch.replace(/\//g, '_');
   return path.join(CACHE_DIR, `pr-${repoId}-${safeBranch}.json`);


### PR DESCRIPTION
## Summary
- Fall back to `git rev-parse --short HEAD` when `git symbolic-ref` fails in test helper, matching `index.js` behavior
- Fixes CI failures caused by GitHub Actions checking out in detached HEAD state

## Test plan
- [x] All 24 tests pass locally
- [ ] CI passes on all Node.js versions (18/20/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)