### PR TITLE
feat: show effort level next to model name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `cwd` | string | Yes | Working directory (used for git info) |
-| `model.display_name` | string | No | Model name (icon changes for "Opus"/"Sonnet"/"Haiku") |
+| `model.display_name` | string | No | Model name (parenthetical suffix like "(1M context)" stripped; icon changes for "Opus"/"Sonnet"/"Haiku") |
 | `context_window.used_percentage` | number | No | Context usage percentage (used for context window bar) |
 | `cost.total_cost_usd` | number | No | Session total cost in USD (used in colleague comments) |
 | `cost.total_duration_ms` | number | No | Session total duration in ms (used in colleague comments) |
@@ -66,6 +66,7 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 - `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model> --no-session-persistence` to generate context-aware comments
 - `--colleague-instruction` flag enables the optional 3rd line with LLM-generated colleague comments
 - Requires `claude` CLI installed and authenticated; silently skips if unavailable
+- Effort level read from `~/.claude/settings.json` `effortLevel` field, displayed next to model name with bolt icon
 - PR review status: `reviewDecision` from `gh pr view` mapped to icons (APPROVED→, CHANGES_REQUESTED→, REVIEW_REQUIRED→)
 - PR cache format: `{ number, url, reviewDecision }` — old caches without `reviewDecision` fall back to no icon
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,16 @@ try {
 }
 
 const cwd = data.cwd || (data.workspace && data.workspace.current_dir) || '';
-const model = (data.model && data.model.display_name) || '';
+const modelRaw = (data.model && data.model.display_name) || '';
+const model = modelRaw.replace(/\s*\(.*?\)\s*$/, '');
+
+// Read effort level from ~/.claude/settings.json
+let effortLevel = '';
+try {
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+  const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  effortLevel = settings.effortLevel || '';
+} catch {}
 const usedPct = data.context_window && data.context_window.used_percentage;
 const costUsd = data.cost && data.cost.total_cost_usd;
 const durationMs = data.cost && data.cost.total_duration_ms;
@@ -198,6 +207,7 @@ const ICON_COMMENT = '\uF075';  //  comment
 const ICON_REVIEW_APPROVED = '\uF00C';   //  check
 const ICON_REVIEW_CHANGES = '\uF00D';    //  close
 const ICON_REVIEW_REQUIRED = '\uF10C';   //  circle-o
+const ICON_BOLT = '\uF0E7';             //  bolt (effort level)
 
 const COL_SEP = '  ';
 
@@ -355,7 +365,8 @@ const termCols = process.stderr.columns || parseInt(process.env.COLUMNS) || 100;
 const LINE_OVERHEAD = 29;
 const maxContentCols = Math.max(30, termCols - LINE_OVERHEAD);
 
-const rawCol1 = Math.max(displayDir.length, model.length);
+const effortSuffix = effortLevel ? ` ${ICON_BOLT}${effortLevel}` : '';
+const rawCol1 = Math.max(displayDir.length, model.length + effortSuffix.length);
 const rawBranchLen = (gitBranch + prText + reviewText).length;
 const rawCol2 = Math.max(rawBranchLen, ctxVisibleLen);
 
@@ -369,7 +380,8 @@ if (rawCol1 + rawCol2 <= maxContentCols) {
 }
 
 const displayDirTrunc = truncStr(displayDir, col1Len);
-const modelTrunc = truncStr(model, col1Len);
+const modelMaxLen = effortSuffix ? Math.max(5, col1Len - effortSuffix.length) : col1Len;
+const modelTrunc = truncStr(model, modelMaxLen);
 const branchMaxLen = Math.max(5, col2Len - prText.length - reviewText.length);
 const gitBranchTrunc = truncStr(gitBranch, branchMaxLen);
 const branchVisible = gitBranchTrunc + prText + reviewText;
@@ -410,7 +422,11 @@ else if (model.includes('Sonnet')) modelIcon = ICON_SONNET;
 else if (model.includes('Haiku')) modelIcon = ICON_HAIKU;
 else modelIcon = ICON_SONNET;
 
-let line2 = `${T.model}${modelIcon} ${padEnd(modelTrunc, col1Len)}${RESET}`;
+const modelPadLen = col1Len - modelTrunc.length - effortSuffix.length;
+const modelPad = modelPadLen > 0 ? ' '.repeat(modelPadLen) : '';
+let line2 = effortSuffix
+  ? `${T.model}${modelIcon} ${modelTrunc}${RESET}${T.dim}${effortSuffix}${modelPad}${RESET}`
+  : `${T.model}${modelIcon} ${padEnd(modelTrunc, col1Len)}${RESET}`;
 
 let remaining = null;
 if (usedPct != null && usedPct !== '') {

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -170,6 +170,38 @@ describe('statusline', () => {
     assert.equal(result.stdout, '');
   });
 
+  it('strips parenthetical suffix from model display_name', () => {
+    const result = run({
+      cwd: '/tmp',
+      model: { display_name: 'Opus 4.6 (1M context)' },
+      context_window: { used_percentage: 30 },
+    });
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes('Opus 4.6'), 'should include base model name');
+    assert.ok(!plain.includes('(1M context)'), 'should not include parenthetical suffix');
+  });
+
+  it('shows effort level from settings with bolt icon', () => {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+    let settings;
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    } catch {
+      settings = {};
+    }
+    if (!settings.effortLevel) {
+      return; // skip if no effort level configured
+    }
+    const result = run({
+      cwd: '/tmp',
+      model: { display_name: 'Opus 4.6' },
+      context_window: { used_percentage: 30 },
+    });
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes(settings.effortLevel), `should include effort level "${settings.effortLevel}"`);
+    assert.ok(result.stdout.includes('\uF0E7'), 'should include bolt icon');
+  });
+
   it('git repo cwd shows branch icon', () => {
     const result = run({
       cwd: path.join(__dirname, '..'),


### PR DESCRIPTION
## Summary
- Strip parenthetical suffix (e.g. "(1M context)") from `model.display_name`
- Read `effortLevel` from `~/.claude/settings.json` and display next to model name with bolt icon (⚡)
- Effort shown in dim color to distinguish from model name
- Example: `Opus 4.6 ⚡high` instead of `Opus 4.6 (1M context)`

## Test plan
- [x] All 26 tests pass (2 new: parenthetical stripping, effort display)
- [x] ESLint clean
- [x] Manual test: "(1M context)" stripped, effort level shown
- [x] Graceful handling when no effortLevel in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)