### PR TITLE
Claude Code statusLine の stdin 新フィールドに準拠

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ Claude Code statusline command (single-file Node.js CLI).
 
 ## Architecture
 
-- Entry point: `index.js` (~500 lines, zero dependencies)
+- Entry point: `index.js` (~430 lines, zero dependencies)
 - Reads JSON from stdin, outputs ANSI-colored 2-line status to stdout
-- Three modes: statusline (default), `--invalidate-cache` (PostToolUse hook), and `--generate-comment` (background LLM comment generation)
+- Two modes: statusline (default) and `--generate-comment` (background LLM comment generation)
 - Modules: child_process, fs, path, os, crypto (all Node.js built-in)
 
 ## Commands
@@ -20,8 +20,11 @@ npm run lint:fix      # ESLint auto-fix
 # Manual test
 echo '{"cwd":"/tmp","model":{"display_name":"Opus 4.6"},"context_window":{"used_percentage":30}}' | node index.js
 
-# Test inside a git repo (shows branch & PR info)
+# Test inside a git repo (shows branch info)
 echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"context_window\":{\"used_percentage\":70}}" | node index.js
+
+# Test PR display (pr.* is provided by Claude Code; pass it manually here)
+echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"pr\":{\"number\":42,\"url\":\"https://github.com/x/y/pull/42\",\"review_state\":\"approved\"}}" | node index.js
 
 # Test with colleague comment (requires cached comment)
 echo "{\"cwd\":\"$(pwd)\",\"model\":{\"display_name\":\"Opus 4.6\"},\"context_window\":{\"used_percentage\":70}}" | node index.js --colleague-instruction 'Be friendly'
@@ -49,15 +52,18 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 | `cost.total_lines_added` | number | No | Total lines added in session (used in colleague comments) |
 | `cost.total_lines_removed` | number | No | Total lines removed in session (used in colleague comments) |
 | `session_id` | string | No | Session ID (used in comment cache key for per-session uniqueness) |
+| `effort.level` | string | No | Reasoning effort level (`low`/`medium`/`high`/`xhigh`/`max`); absent if model doesn't support it. Reflects mid-session `/effort` changes |
+| `workspace.current_dir` | string | No | Fallback source for `cwd` when `cwd` is absent |
+| `pr.number` | number | No | Open PR number (Claude Code native; absent when no PR or PR merged/closed) |
+| `pr.url` | string | No | Open PR URL (used for OSC8 clickable link) |
+| `pr.review_state` | string | No | PR review state (`approved`/`pending`/`changes_requested`/`draft`); absent if no review |
 
 ## Key Implementation Details
 
-- PR info cached at `~/.claude/cache/pr-<repoHash>-<branch>.json` (TTL: 5 min, override with `STATUSLINE_PR_CACHE_TTL_MS`)
-- repoHash is first 8 chars of MD5 of `git rev-parse --show-toplevel`
+- PR info (number, URL, review state) read directly from stdin `pr.*` — no `gh` call or cache file
 - Context window bar converts used_percentage to "remaining until 85% (auto-compact threshold)"
 - OSC8 hyperlinks use BEL (`\x07`) terminator
-- All git commands have `timeout: 3000ms`; `gh` commands use `timeout 2`
-- `--invalidate-cache` mode: deletes cache file when `gh pr create/merge/close/review` is detected in PostToolUse hook input
+- All git commands have `timeout: 3000ms`
 - Comment cache at `~/.claude/cache/statusline-comment-<hash>.json` where hash = MD5(toplevel + session_id)[:8] (TTL: 5 min, override with `STATUSLINE_COMMENT_TTL_MS`)
 - Comment cache format: `{ comment: "text", history: ["prev1", "prev2", ...] }` — history keeps last N comments for dedup
 - Comment prompt: instruction first (persona adherence), dynamic context (empty fields omitted), changedFiles max 5
@@ -67,17 +73,15 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 - `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model> --no-session-persistence` to generate context-aware comments
 - `--colleague-instruction` flag enables the optional 3rd line with LLM-generated colleague comments
 - Requires `claude` CLI installed and authenticated; silently skips if unavailable
-- Effort level read from `~/.claude/settings.json` `effortLevel` field, displayed next to model name with bolt icon
+- Effort level: stdin `effort.level` preferred, `~/.claude/settings.json` `effortLevel` as fallback; shown next to model name with bolt icon
 - Terminal width detection: `process.stderr.columns` → `COLUMNS` env → default 100; columns dynamically capped to fit
 - Model display_name parenthetical suffix (e.g. "(1M context)") auto-stripped; time format is `HH:MM:SS`
-- PR review status: `reviewDecision` from `gh pr view` mapped to icons (APPROVED→, CHANGES_REQUESTED→, REVIEW_REQUIRED→)
-- PR cache format: `{ number, url, reviewDecision }` — old caches without `reviewDecision` fall back to no icon
+- PR review status: stdin `pr.review_state` mapped to icons (approved→, changes_requested→, pending→, draft→)
 
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `STATUSLINE_PR_CACHE_TTL_MS` | `300000` (5 min) | PR info cache TTL |
 | `STATUSLINE_COMMENT_MODEL` | `haiku` | Model alias for `claude -p --model` |
 | `STATUSLINE_COMMENT_TTL_MS` | `300000` (5 min) | Colleague comment cache TTL |
 | `STATUSLINE_COMMENT_HISTORY_SIZE` | `5` | Number of previous comments to track for dedup |
@@ -91,8 +95,11 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 
 ## Gotchas
 
-- If `gh` CLI is not installed, PR info is silently skipped (no error)
+- PR info comes from Claude Code's stdin `pr.*`; absent when no open PR exists (no error)
 - Invalid JSON on stdin causes silent exit (`process.exit(0)`, no output)
+- Statusline re-runs only on Claude Code triggers (new message, `/compact`, permission/vim mode change), debounced 300ms
+- The `HH:MM:SS` clock goes stale between triggers; users wanting a live clock set `statusLine.refreshInterval` (seconds) in settings.json
+- `statusLine.hideVimModeIndicator` (settings.json) hides Claude Code's own vim indicator; unrelated to this command's output
 - Icons require a [Nerd Font](https://www.nerdfonts.com/) in the terminal
 - OSC8 hyperlinks don't work in some terminal emulators (Claude Code limitation: [anthropics/claude-code#26356](https://github.com/anthropics/claude-code/issues/26356)). Works in IDE integrated terminals (VS Code, Cursor), but may render as plain text in standalone emulators (Konsole, Windows Terminal)
 - If `claude` CLI is not installed or not authenticated, colleague comments are silently skipped

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) statusline comma
 ## Requirements
 
 - [Nerd Font](https://www.nerdfonts.com/) (terminal font)
-- [GitHub CLI](https://cli.github.com/) (`gh`) for PR links
 - Node.js >= 18
 
 ## Setup
@@ -33,6 +32,20 @@ Add to `~/.claude/settings.json`:
   "statusLine": {
     "type": "command",
     "command": "npx -y sai-kaneko-31/cc-statusline"
+  }
+}
+```
+
+### Live-updating clock
+
+The statusline re-runs only when Claude Code emits an event (new message, `/compact`, mode change). To keep the `HH:MM:SS` clock current, add `refreshInterval` (seconds):
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "npx -y sai-kaneko-31/cc-statusline",
+    "refreshInterval": 10
   }
 }
 ```
@@ -55,12 +68,13 @@ Line 2: 🔲 <model>        ❤️ [<bar>]<remaining>%       🕐 <time>
 
 ### PR review status icons
 
-| reviewDecision | Icon | Color | Meaning |
-|----------------|------|-------|---------|
-| `APPROVED` | `` (check) | Green | PR approved |
-| `CHANGES_REQUESTED` | `` (close) | Red | Changes requested |
-| `REVIEW_REQUIRED` | `` (circle-o) | Yellow | Review pending |
-| (empty) | — | — | No icon shown |
+| `pr.review_state` | Icon | Color | Meaning |
+|-------------------|------|-------|---------|
+| `approved` | `` (check) | Green | PR approved |
+| `changes_requested` | `` (close) | Red | Changes requested |
+| `pending` | `` (circle-o) | Yellow | Review pending |
+| `draft` | `` (pencil) | Dim | Draft PR |
+| (absent) | — | — | No icon shown |
 
 ### Context window bar color
 
@@ -70,41 +84,9 @@ Line 2: 🔲 <model>        ❤️ [<bar>]<remaining>%       🕐 <time>
 | 16-40% | Yellow | Getting low |
 | 0-15% | Red | Auto-compact imminent |
 
-## PR link caching
+## PR display
 
-PR data is cached at `~/.claude/cache/pr-<repo-hash>-<branch>.json` with a 5-minute TTL.
-
-Override TTL with environment variable:
-
-```json
-{
-  "env": {
-    "STATUSLINE_PR_CACHE_TTL_MS": "60000"
-  }
-}
-```
-
-### Auto-invalidation hook
-
-Add a PostToolUse hook to auto-invalidate the cache when `gh pr create/merge/close/review` is executed:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx -y sai-kaneko-31/cc-statusline --invalidate-cache"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+PR number, URL, and review state come from Claude Code's stdin `pr.*` fields — no `gh` CLI, cache, or hook required. The PR number renders as an OSC8 clickable link to the PR URL, and `pr.review_state` drives the review icon.
 
 ## Colleague comments (optional)
 

--- a/index.js
+++ b/index.js
@@ -7,34 +7,6 @@ const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 
-// ── --invalidate-cache mode (PostToolUse hook) ──
-if (process.argv.includes('--invalidate-cache')) {
-  try {
-    const input = JSON.parse(fs.readFileSync(0, 'utf8'));
-    const cmd = (input.tool_input && input.tool_input.command) || '';
-    if (!/gh\s+pr\s+(create|merge|close|review)/.test(cmd)) process.exit(0);
-
-    const homeDir = os.homedir();
-    const cacheDir = path.join(homeDir, '.claude', 'cache');
-    if (!fs.existsSync(cacheDir)) process.exit(0);
-
-    const branch = execSync('git symbolic-ref --short HEAD', {
-      encoding: 'utf8',
-      timeout: 3000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    const toplevel = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf8',
-      timeout: 3000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    const repoId = crypto.createHash('md5').update(toplevel).digest('hex').slice(0, 8);
-    const cacheFile = path.join(cacheDir, `pr-${repoId}-${branch.replace(/\//g, '_')}.json`);
-    fs.rmSync(cacheFile, { force: true });
-  } catch {}
-  process.exit(0);
-}
-
 // ── --generate-comment mode (background LLM comment generation) ──
 const generateCommentIdx = process.argv.indexOf('--generate-comment');
 if (generateCommentIdx !== -1) {
@@ -115,13 +87,18 @@ const cwd = data.cwd || (data.workspace && data.workspace.current_dir) || '';
 const modelRaw = (data.model && data.model.display_name) || '';
 const model = modelRaw.replace(/\s*\(.*?\)\s*$/, '');
 
-// Read effort level from ~/.claude/settings.json
-let effortLevel = '';
-try {
-  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-  const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-  effortLevel = settings.effortLevel || '';
-} catch {}
+// Effort level: prefer stdin `effort.level` (reflects mid-session /effort
+// changes; values: low/medium/high/xhigh/max). Fall back to
+// ~/.claude/settings.json `effortLevel` for older Claude Code versions
+// that don't send the field.
+let effortLevel = (data.effort && data.effort.level) || '';
+if (!effortLevel) {
+  try {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    effortLevel = settings.effortLevel || '';
+  } catch {}
+}
 const usedPct = data.context_window && data.context_window.used_percentage;
 const costUsd = data.cost && data.cost.total_cost_usd;
 const durationMs = data.cost && data.cost.total_duration_ms;
@@ -206,7 +183,8 @@ const ICON_CLOCK = '\uF017';    //  clock
 const ICON_COMMENT = '\uF075';  //  comment
 const ICON_REVIEW_APPROVED = '\uF00C';   //  check
 const ICON_REVIEW_CHANGES = '\uF00D';    //  close
-const ICON_REVIEW_REQUIRED = '\uF10C';   //  circle-o
+const ICON_REVIEW_PENDING = '\uF10C';    //  circle-o
+const ICON_REVIEW_DRAFT = '\uF040';      //  pencil
 const ICON_BOLT = '\u26A1';              // ⚡ bolt (effort level, full-width)
 
 const COL_SEP = '  ';
@@ -252,9 +230,11 @@ let gitBranch = '';
 let gitAheadBehind = '';
 let gitAdded = '';
 let gitDeleted = '';
-let prNum = '';
-let prUrl = '';
-let prReviewDecision = '';
+// PR info from stdin: Claude Code provides pr.{number,url,review_state}
+// natively (absent when not in a git repo, no PR, or PR merged/closed).
+const prNum = data.pr && data.pr.number != null ? String(data.pr.number) : '';
+const prUrl = (data.pr && data.pr.url) || '';
+const prReviewDecision = (data.pr && data.pr.review_state) || '';
 
 if (exec(`git -C "${cwd}" rev-parse --git-dir`)) {
   gitBranch =
@@ -285,61 +265,6 @@ if (exec(`git -C "${cwd}" rev-parse --git-dir`)) {
     if (addMatch) gitAdded = addMatch[1];
     if (delMatch) gitDeleted = delMatch[1];
   }
-
-  // PR info with file-based cache
-  if (gitBranch) {
-    const cacheDir = path.join(homeDir, '.claude', 'cache');
-    const ttl = parseInt(process.env.STATUSLINE_PR_CACHE_TTL_MS) || 300000;
-    try {
-      fs.mkdirSync(cacheDir, { recursive: true });
-    } catch {}
-
-    const toplevel = exec(`git -C "${cwd}" rev-parse --show-toplevel`);
-    const repoId = crypto
-      .createHash('md5')
-      .update(toplevel)
-      .digest('hex')
-      .slice(0, 8);
-    const safeBranch = gitBranch.replace(/\//g, '_');
-    const cacheFile = path.join(cacheDir, `pr-${repoId}-${safeBranch}.json`);
-
-    let cached = null;
-    try {
-      const stat = fs.statSync(cacheFile);
-      if (Date.now() - stat.mtimeMs < ttl) {
-        cached = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
-      }
-    } catch {}
-
-    if (cached === null) {
-      const remoteUrl = exec(`git -C "${cwd}" remote get-url origin`);
-      const prJson = exec(
-        `timeout 2 gh pr view "${gitBranch}" --repo "${remoteUrl}" --json number,url,state,reviewDecision`
-      );
-      if (prJson) {
-        try {
-          const pr = JSON.parse(prJson);
-          cached =
-            pr.state === 'OPEN'
-              ? { number: pr.number, url: pr.url, reviewDecision: pr.reviewDecision || '' }
-              : { none: true };
-        } catch {
-          cached = { none: true };
-        }
-      } else {
-        cached = { none: true };
-      }
-      try {
-        fs.writeFileSync(cacheFile, JSON.stringify(cached));
-      } catch {}
-    }
-
-    if (cached && !cached.none) {
-      prNum = String(cached.number);
-      prUrl = cached.url;
-      prReviewDecision = cached.reviewDecision || '';
-    }
-  }
 }
 
 // ── Time ──
@@ -348,10 +273,12 @@ const p2 = (n) => String(n).padStart(2, '0');
 const currentTime = `${p2(now.getHours())}:${p2(now.getMinutes())}:${p2(now.getSeconds())}`;
 
 // ── Column widths ──
+// Keyed by stdin pr.review_state (approved/pending/changes_requested/draft)
 const REVIEW_MAP = {
-  APPROVED: { icon: ICON_REVIEW_APPROVED, color: T.added },
-  CHANGES_REQUESTED: { icon: ICON_REVIEW_CHANGES, color: T.deleted },
-  REVIEW_REQUIRED: { icon: ICON_REVIEW_REQUIRED, color: T.aheadBehind },
+  approved: { icon: ICON_REVIEW_APPROVED, color: T.added },
+  changes_requested: { icon: ICON_REVIEW_CHANGES, color: T.deleted },
+  pending: { icon: ICON_REVIEW_PENDING, color: T.aheadBehind },
+  draft: { icon: ICON_REVIEW_DRAFT, color: T.dim },
 };
 const reviewInfo = REVIEW_MAP[prReviewDecision] || null;
 const prText = prNum ? ` #${prNum}` : '';
@@ -396,7 +323,11 @@ if (gitBranch) {
   if (prNum) {
     // Branch name + OSC8 clickable PR link + review status
     const reviewStr = reviewInfo ? ` ${reviewInfo.color}${reviewInfo.icon}${RESET}` : '';
-    line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${gitBranchTrunc}${RESET} ${T.dim}${osc8(`#${prNum}`, prUrl)}${RESET}${reviewStr}${padding}`;
+    // Wrap the PR number in an OSC8 link only when pr.url is present.
+    // pr.number can arrive from stdin without pr.url, and osc8 with an
+    // empty url emits a broken hyperlink (and 2 wasted ANSI transitions).
+    const prLabel = prUrl ? osc8(`#${prNum}`, prUrl) : `#${prNum}`;
+    line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${gitBranchTrunc}${RESET} ${T.dim}${prLabel}${RESET}${reviewStr}${padding}`;
   } else {
     line1 += `${COL_SEP}${T.branch}${ICON_BRANCH} ${padEnd(gitBranchTrunc, col2Len)}${RESET}`;
   }

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -5,8 +5,6 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const crypto = require('crypto');
-
 const INDEX = path.join(__dirname, '..', 'index.js');
 const CACHE_DIR = path.join(os.homedir(), '.claude', 'cache');
 // /tmp is not a git repo, so cacheKey falls back to 'default'
@@ -52,26 +50,6 @@ function runWithArgs(input, args = [], options = {}) {
 
 function cleanCommentCache() {
   try { fs.rmSync(COMMENT_CACHE, { force: true }); } catch {}
-}
-
-function getPrCacheFile(cwd) {
-  const toplevel = execFileSync('git', ['-C', cwd, 'rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
-  let branch;
-  try {
-    branch = execFileSync('git', ['-C', cwd, 'symbolic-ref', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
-  } catch {
-    branch = execFileSync('git', ['-C', cwd, 'rev-parse', '--short', 'HEAD'], { encoding: 'utf8' }).trim();
-  }
-  const repoId = crypto.createHash('md5').update(toplevel).digest('hex').slice(0, 8);
-  const safeBranch = branch.replace(/\//g, '_');
-  return path.join(CACHE_DIR, `pr-${repoId}-${safeBranch}.json`);
-}
-
-function createPrCache(cwd, prData) {
-  const cacheFile = getPrCacheFile(cwd);
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-  fs.writeFileSync(cacheFile, JSON.stringify(prData));
-  return cacheFile;
 }
 
 // Strip ANSI escape codes and OSC8 hyperlink sequences
@@ -179,6 +157,42 @@ describe('statusline', () => {
     const plain = stripAnsi(result.stdout);
     assert.ok(plain.includes('Opus 4.6'), 'should include base model name');
     assert.ok(!plain.includes('(1M context)'), 'should not include parenthetical suffix');
+  });
+
+  it('shows effort level from stdin effort.level with bolt icon', () => {
+    const result = run({
+      cwd: '/tmp',
+      model: { display_name: 'Opus 4.6' },
+      context_window: { used_percentage: 30 },
+      effort: { level: 'high' },
+    });
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes('high'), 'should include effort level from stdin');
+    assert.ok(result.stdout.includes('⚡'), 'should include bolt icon');
+  });
+
+  it('stdin effort.level takes precedence over settings.json effortLevel', () => {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+    let settings;
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    } catch {
+      settings = {};
+    }
+    if (!settings.effortLevel) {
+      return; // skip if no effort level in settings to compare against
+    }
+    // Pick a stdin value guaranteed to differ from the settings value
+    const stdinLevel = settings.effortLevel === 'low' ? 'max' : 'low';
+    const result = run({
+      cwd: '/tmp',
+      model: { display_name: 'Opus 4.6' },
+      context_window: { used_percentage: 30 },
+      effort: { level: stdinLevel },
+    });
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes(stdinLevel), `should show stdin effort level "${stdinLevel}"`);
+    assert.ok(!plain.includes(settings.effortLevel), `should not show settings effortLevel "${settings.effortLevel}" when stdin provides one`);
   });
 
   it('shows effort level from settings with bolt icon', () => {
@@ -292,79 +306,69 @@ describe('colleague comments', () => {
 });
 
 describe('PR review status', () => {
-  const stdinData = {
-    cwd: REPO_CWD,
-    model: { display_name: 'Opus 4.6' },
-    context_window: { used_percentage: 30 },
-  };
-
-  let cacheFile;
-
-  function cleanPrCache() {
-    if (cacheFile) {
-      try { fs.rmSync(cacheFile, { force: true }); } catch {}
-    }
+  // PR info comes from stdin `pr.{number,url,review_state}` (Claude Code native)
+  function stdinWithPr(pr) {
+    const data = {
+      cwd: REPO_CWD,
+      model: { display_name: 'Opus 4.6' },
+      context_window: { used_percentage: 30 },
+    };
+    if (pr) data.pr = pr;
+    return data;
   }
 
-  it('APPROVED shows check icon', () => {
-    cacheFile = createPrCache(REPO_CWD, { number: 99, url: 'https://github.com/test/repo/pull/99', reviewDecision: 'APPROVED' });
-    try {
-      const result = run(stdinData);
-      assert.equal(result.exitCode, 0);
-      assert.ok(result.stdout.includes('\uF00C'), 'should include check icon for APPROVED');
-      const plain = stripAnsi(result.stdout);
-      assert.ok(plain.includes('#99'), 'should include PR number');
-    } finally {
-      cleanPrCache();
-    }
+  it('approved shows check icon', () => {
+    const result = run(stdinWithPr({ number: 99, url: 'https://github.com/test/repo/pull/99', review_state: 'approved' }));
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\uF00C'), 'should include check icon for approved');
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes('#99'), 'should include PR number');
   });
 
-  it('CHANGES_REQUESTED shows close icon', () => {
-    cacheFile = createPrCache(REPO_CWD, { number: 100, url: 'https://github.com/test/repo/pull/100', reviewDecision: 'CHANGES_REQUESTED' });
-    try {
-      const result = run(stdinData);
-      assert.equal(result.exitCode, 0);
-      assert.ok(result.stdout.includes('\uF00D'), 'should include close icon for CHANGES_REQUESTED');
-    } finally {
-      cleanPrCache();
-    }
+  it('changes_requested shows close icon', () => {
+    const result = run(stdinWithPr({ number: 100, url: 'https://github.com/test/repo/pull/100', review_state: 'changes_requested' }));
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\uF00D'), 'should include close icon for changes_requested');
   });
 
-  it('REVIEW_REQUIRED shows circle-o icon', () => {
-    cacheFile = createPrCache(REPO_CWD, { number: 101, url: 'https://github.com/test/repo/pull/101', reviewDecision: 'REVIEW_REQUIRED' });
-    try {
-      const result = run(stdinData);
-      assert.equal(result.exitCode, 0);
-      assert.ok(result.stdout.includes('\uF10C'), 'should include circle-o icon for REVIEW_REQUIRED');
-    } finally {
-      cleanPrCache();
-    }
+  it('pending shows circle-o icon', () => {
+    const result = run(stdinWithPr({ number: 101, url: 'https://github.com/test/repo/pull/101', review_state: 'pending' }));
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\uF10C'), 'should include circle-o icon for pending');
   });
 
-  it('empty reviewDecision shows no review icon', () => {
-    cacheFile = createPrCache(REPO_CWD, { number: 102, url: 'https://github.com/test/repo/pull/102', reviewDecision: '' });
-    try {
-      const result = run(stdinData);
-      assert.equal(result.exitCode, 0);
-      assert.ok(!result.stdout.includes('\uF00C'), 'should not include check icon');
-      assert.ok(!result.stdout.includes('\uF00D'), 'should not include close icon');
-      assert.ok(!result.stdout.includes('\uF10C'), 'should not include circle-o icon');
-    } finally {
-      cleanPrCache();
-    }
+  it('draft shows pencil icon', () => {
+    const result = run(stdinWithPr({ number: 104, url: 'https://github.com/test/repo/pull/104', review_state: 'draft' }));
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stdout.includes('\uF040'), 'should include pencil icon for draft');
   });
 
-  it('legacy cache without reviewDecision shows no review icon', () => {
-    cacheFile = createPrCache(REPO_CWD, { number: 103, url: 'https://github.com/test/repo/pull/103' });
-    try {
-      const result = run(stdinData);
-      assert.equal(result.exitCode, 0);
-      assert.ok(!result.stdout.includes('\uF00C'), 'should not include check icon');
-      assert.ok(!result.stdout.includes('\uF00D'), 'should not include close icon');
-      assert.ok(!result.stdout.includes('\uF10C'), 'should not include circle-o icon');
-    } finally {
-      cleanPrCache();
-    }
+  it('PR without review_state shows no review icon', () => {
+    const result = run(stdinWithPr({ number: 102, url: 'https://github.com/test/repo/pull/102' }));
+    assert.equal(result.exitCode, 0);
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes('#102'), 'should still include PR number');
+    assert.ok(!result.stdout.includes('\uF00C'), 'should not include check icon');
+    assert.ok(!result.stdout.includes('\uF00D'), 'should not include close icon');
+    assert.ok(!result.stdout.includes('\uF10C'), 'should not include circle-o icon');
+    assert.ok(!result.stdout.includes('\uF040'), 'should not include pencil icon');
+  });
+
+  it('PR number without url renders plain (no broken OSC8 link)', () => {
+    const result = run(stdinWithPr({ number: 200 }));
+    assert.equal(result.exitCode, 0);
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes('#200'), 'should still show PR number');
+    // osc8() with an empty url emits a hyperlink escape (ESC ] 8 ; ;).
+    // When pr.url is absent the number must render as plain text.
+    assert.ok(!result.stdout.includes('\x1b]8;;'), 'should not emit an OSC8 hyperlink without a url');
+  });
+
+  it('no pr field shows no PR number', () => {
+    const result = run(stdinWithPr(null));
+    assert.equal(result.exitCode, 0);
+    const plain = stripAnsi(result.stdout);
+    assert.ok(!plain.includes('#'), 'should not include any PR number');
   });
 });
 


### PR DESCRIPTION
最新の Claude Code statusLine 仕様（[公式ドキュメント](https://code.claude.com/docs/en/statusline.md)）では effort level と PR 情報が stdin で提供されるようになったため、自前取得をやめてネイティブ提供値に追従する。

## ① effort level の stdin 準拠

- `~/.claude/settings.json` の `effortLevel` 読み取り → stdin の `effort.level` 優先に変更
- 動機: settings.json 読みでは `/effort` のセッション中変更が反映されない。`effortLevel` キーの存在も仕様上保証されていなかった
- 旧 Claude Code 向けに settings.json をフォールバックとして残す

## ② PR 情報の stdin 完全移行

- `gh pr view` + ファイルキャッシュ + `--invalidate-cache` PostToolUse hook を**全廃**
- stdin の `pr.{number, url, review_state}` を直読み
- `REVIEW_MAP` を新形式（`approved` / `pending` / `changes_requested` / `draft`）に刷新し、draft 用ペンシルアイコン (``) を追加
- 各フィールドを独立に読むため、`pr.url` 欠落時は空の OSC8 リンク (`\x1b]8;;\x07...`) を出さずプレーンテキストで描画
- 環境変数 \`STATUSLINE_PR_CACHE_TTL_MS\` は廃止

### ⚠️ 互換性についての割り切り

旧 Claude Code（\`pr.*\` を送らないバージョン）では PR 情報が表示されなくなる。完全移行のため許容。

## ④ ドキュメント

- stdin フィールド表に \`effort.level\` / \`workspace.current_dir\` / \`pr.*\` を追加
- \`statusLine.refreshInterval\` を gotcha に追記（時計の \`HH:MM:SS\` 鮮度に直結）
- \`statusLine.hideVimModeIndicator\` も補足
- README から \`gh\` CLI 前提を削除、PR 表示の説明を簡潔化

## 検証

- \`npm test\`: **30/30 パス**（effort stdin / 優先順位 / PR review_state 4 種 / pr.url 欠落 / pr フィールド欠落 など回帰テスト追加）
- \`npm run lint\`: クリーン
- スモークテスト: PR draft + effort high の表示を目視確認

## diff stat

| ファイル | 変更 |
|---|---|
| \`index.js\` | 127 行変更（実質 -76 行） |
| \`test/statusline.test.js\` | 172 行変更 |
| \`CLAUDE.md\` | 31 行変更 |
| \`README.md\` | 64 行変更 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)