### PR TITLE
日本語コメントの visual width 境界切断 (truncStrVisual)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_DISABLE_BACKGROUND_TA
 - Comment prompt: instruction first (persona adherence), dynamic context (empty fields omitted), changedFiles max 5
 - Comment prompt priority: changed files > branch > time > duration/cost; context window remaining only shown if <15%
 - Comment dedup uses positive instruction ("say something different") instead of negative ("DO NOT repeat")
-- Comment output sanitized: newlines collapsed, truncated to 80 chars at generation, further truncated to terminal width at display
+- Comment output sanitized: newlines collapsed, capped to 200 codepoints at generation (safety net, surrogate-pair safe)
+- Comment display uses `truncStrVisual` (visual-cell width: CJK/emoji = 2 cells); separate from char-based `truncStr` for path/model/branch layout
 - `--generate-comment` mode: spawned as detached background process, calls `claude -p --model <model> --no-session-persistence` to generate context-aware comments
 - `--colleague-instruction` flag enables the optional 3rd line with LLM-generated colleague comments
 - Requires `claude` CLI installed and authenticated; silently skips if unavailable

--- a/index.js
+++ b/index.js
@@ -53,8 +53,10 @@ if (generateCommentIdx !== -1) {
       env,
     }).trim();
 
-    // Sanitize: collapse to single line, truncate to 120 chars
-    const result = raw.replace(/[\r\n]+/g, ' ').slice(0, 80);
+    // Sanitize: collapse to single line. Cap to 200 codepoints (not UTF-16
+    // units, so we don't split a surrogate pair mid-emoji); final cell-width
+    // truncation happens at display time via truncStrVisual.
+    const result = [...raw.replace(/[\r\n]+/g, ' ')].slice(0, 200).join('');
 
     if (result) {
       const homeDir = os.homedir();
@@ -212,11 +214,62 @@ function padEnd(str, len) {
   return str.length < len ? str + ' '.repeat(len - str.length) : str;
 }
 
-// Truncate string with ellipsis if too long
+// Truncate string with ellipsis if too long (UTF-16 unit based).
+// Used by the 2-line column layout (path/model/branch) where surrounding
+// width arithmetic (rawCol1, padEnd) also uses .length \u2014 switching this
+// to visual width would desync the column alignment for wide-char paths.
 function truncStr(str, maxLen) {
   if (str.length <= maxLen) return str;
   if (maxLen < 2) return str.slice(0, 1);
   return str.slice(0, maxLen - 1) + '\u2026';
+}
+
+// Visual display width: CJK / fullwidth / emoji count as 2 cells, rest as 1.
+// Used only by truncStrVisual below, which handles the colleague comment
+// line where wide-char content (Japanese, emoji) is common.
+function visualWidth(str) {
+  let w = 0;
+  for (const ch of str) {
+    const code = ch.codePointAt(0);
+    if (
+      (code >= 0x1100 && code <= 0x115F) ||      // Hangul Jamo
+      (code >= 0x2600 && code <= 0x27BF) ||      // Misc Symbols + Dingbats (\u26a1 \u2764 \u2728)
+      (code >= 0x2E80 && code <= 0x303F) ||      // CJK Radicals / Symbols / Punctuation
+      (code >= 0x3041 && code <= 0x33FF) ||      // Hiragana / Katakana / CJK Symbols
+      (code >= 0x3400 && code <= 0x4DBF) ||      // CJK Extension A
+      (code >= 0x4E00 && code <= 0x9FFF) ||      // CJK Unified Ideographs
+      (code >= 0xA000 && code <= 0xA4CF) ||      // Yi
+      (code >= 0xAC00 && code <= 0xD7A3) ||      // Hangul Syllables
+      (code >= 0xF900 && code <= 0xFAFF) ||      // CJK Compatibility Ideographs
+      (code >= 0xFE30 && code <= 0xFE4F) ||      // CJK Compatibility Forms
+      (code >= 0xFF00 && code <= 0xFF60) ||      // Fullwidth forms
+      (code >= 0xFFE0 && code <= 0xFFE6) ||      // Fullwidth signs
+      (code >= 0x1F300 && code <= 0x1F9FF) ||    // Emoji: pictographs / emoticons / etc.
+      (code >= 0x1FA70 && code <= 0x1FAFF)       // Emoji extended
+    ) {
+      w += 2;
+    } else {
+      w += 1;
+    }
+  }
+  return w;
+}
+
+// Truncate to maxWidth visual cells (CJK/emoji = 2), appending ellipsis.
+// Use this for free-form text (Japanese colleague comments) where the
+// caller's budget is in terminal cells rather than UTF-16 units.
+function truncStrVisual(str, maxWidth) {
+  if (visualWidth(str) <= maxWidth) return str;
+  if (maxWidth < 2) return [...str][0] || '';
+  let w = 0;
+  let result = '';
+  for (const ch of str) {
+    const chWidth = visualWidth(ch);
+    if (w + chWidth > maxWidth - 1) break; // reserve 1 cell for ellipsis
+    result += ch;
+    w += chWidth;
+  }
+  return result + '\u2026';
 }
 
 // Directory: replace $HOME with ~
@@ -433,6 +486,6 @@ if (colleagueInstruction !== null) {
 let output = `${line1}\n${line2}`;
 if (cachedComment) {
   const commentMaxLen = Math.max(20, termCols - 4);
-  output += `\n${T.dim}${ICON_COMMENT} ${truncStr(cachedComment, commentMaxLen)}${RESET}`;
+  output += `\n${T.dim}${ICON_COMMENT} ${truncStrVisual(cachedComment, commentMaxLen)}${RESET}`;
 }
 process.stdout.write(output);

--- a/test/statusline.test.js
+++ b/test/statusline.test.js
@@ -136,6 +136,25 @@ describe('statusline', () => {
     assert.equal(lines.length, 2);
   });
 
+  it('non-ASCII cwd column truncation stays in char units, not visual cells', () => {
+    // Regression guard for truncStr semantics. With COLUMNS=50, col1Len is
+    // forced down to ~15 chars, so a 29-char wide-char path DOES trigger
+    // truncation. Under char-based truncStr (correct), 'プロジェクト' fits
+    // in the first 14 chars + ellipsis. Under visual-cell truncStr (the
+    // regression), the kana run would be cut at 'プロジェ…' because each
+    // wide char counts as 2 cells against the same 15 budget.
+    const longCwd = '/tmp/プロジェクト/サブディレクトリ/さらに深いところ';
+    const result = runWithArgs(
+      { cwd: longCwd, model: { display_name: 'Opus 4.6' } },
+      [],
+      { env: { ...process.env, COLUMNS: '50' } }
+    );
+    assert.equal(result.exitCode, 0);
+    const plain = stripAnsi(result.stdout);
+    assert.ok(plain.includes('プロジェクト'), `char-based truncStr must keep 'プロジェクト' intact: ${JSON.stringify(plain)}`);
+    assert.ok(!plain.includes('プロジェ…'), `must not cut at visual-cell boundary 'プロジェ…': ${JSON.stringify(plain)}`);
+  });
+
   it('invalid JSON exits with 0 and no output', () => {
     const result = run('not json');
     assert.equal(result.exitCode, 0);
@@ -299,6 +318,125 @@ describe('colleague comments', () => {
       assert.equal(result.exitCode, 0);
       const lines = result.stdout.split('\n');
       assert.equal(lines.length, 2, 'should output 2 lines when cache is stale');
+    } finally {
+      cleanCommentCache();
+    }
+  });
+
+  // Visual-cell width helper mirroring index.js#visualWidth so tests can assert
+  // the post-truncation body stays within terminal columns regardless of the
+  // mix of ASCII / kana / kanji / emoji / dingbats in the input.
+  function vw(s) {
+    let w = 0;
+    for (const ch of s) {
+      const c = ch.codePointAt(0);
+      const wide =
+        (c >= 0x1100 && c <= 0x115F) ||
+        (c >= 0x2600 && c <= 0x27BF) ||
+        (c >= 0x2E80 && c <= 0x303F) ||
+        (c >= 0x3041 && c <= 0x33FF) ||
+        (c >= 0x3400 && c <= 0x4DBF) ||
+        (c >= 0x4E00 && c <= 0x9FFF) ||
+        (c >= 0xA000 && c <= 0xA4CF) ||
+        (c >= 0xAC00 && c <= 0xD7A3) ||
+        (c >= 0xF900 && c <= 0xFAFF) ||
+        (c >= 0xFE30 && c <= 0xFE4F) ||
+        (c >= 0xFF00 && c <= 0xFF60) ||
+        (c >= 0xFFE0 && c <= 0xFFE6) ||
+        (c >= 0x1F300 && c <= 0x1F9FF) ||
+        (c >= 0x1FA70 && c <= 0x1FAFF);
+      w += wide ? 2 : 1;
+    }
+    return w;
+  }
+
+  // Render a cached comment under COLUMNS=40 and return the comment-line body
+  // (after the icon + space prefix) along with the full stripped line.
+  function renderCachedComment(comment, columns = '40') {
+    fs.mkdirSync(path.dirname(COMMENT_CACHE), { recursive: true });
+    fs.writeFileSync(COMMENT_CACHE, JSON.stringify({ comment }));
+    const result = runWithArgs(stdinData, ['--colleague-instruction', 'test'], {
+      env: { ...process.env, COLUMNS: columns },
+    });
+    assert.equal(result.exitCode, 0);
+    const lines = result.stdout.split('\n');
+    assert.equal(lines.length, 3, 'should still emit a comment line');
+    const commentLine = stripAnsi(lines[2]);
+    // Strip leading icon (private-use Nerd Font glyph, 1 cell) and the space.
+    const body = commentLine.replace(/^[^\s]\s/, '');
+    return { commentLine, body };
+  }
+
+  it('long Japanese comment is truncated at visual-cell budget with ellipsis', () => {
+    cleanCommentCache();
+    try {
+      // 60 hiragana chars = ~120 visual cells; with COLUMNS=40 (budget=36),
+      // the comment must be cut and end with …
+      const longComment = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこ';
+      const { body } = renderCachedComment(longComment);
+      assert.ok(body.endsWith('…'), `should end with ellipsis: ${JSON.stringify(body)}`);
+      assert.ok(vw(body) <= 36, `truncated body visual width ${vw(body)} should fit COLUMNS-4=36`);
+    } finally {
+      cleanCommentCache();
+    }
+  });
+
+  it('long ASCII comment is truncated with ellipsis (legacy code-unit semantics preserved)', () => {
+    cleanCommentCache();
+    try {
+      // 80 ASCII chars = 80 visual cells; with COLUMNS=40 (budget=36),
+      // the legacy behavior was: result length === budget (35 chars + …).
+      // visualWidth(ASCII)==length, so the new semantics must produce the
+      // identical output for ASCII-only input.
+      const longComment = 'a'.repeat(80);
+      const { body } = renderCachedComment(longComment);
+      assert.ok(body.endsWith('…'), `should end with ellipsis: ${JSON.stringify(body)}`);
+      // ASCII => visual width === string length; truncated to exactly budget.
+      assert.equal(body.length, 36, `ASCII truncation length should equal budget: got ${body.length}`);
+      assert.equal(vw(body), 36, `ASCII visual width should equal budget`);
+      // The kept prefix must be the original characters (no width-rounding loss).
+      assert.equal(body.slice(0, 35), 'a'.repeat(35));
+    } finally {
+      cleanCommentCache();
+    }
+  });
+
+  it('long CJK ideograph comment is truncated at visual-cell budget', () => {
+    cleanCommentCache();
+    try {
+      // 「漢」 = U+6F22 (CJK Unified Ideographs, range 0x4E00-0x9FFF, width 2).
+      // 40 kanji = 80 cells; budget 36 => must be cut.
+      const longComment = '漢'.repeat(40);
+      const { body } = renderCachedComment(longComment);
+      assert.ok(body.endsWith('…'), `should end with ellipsis: ${JSON.stringify(body)}`);
+      assert.ok(vw(body) <= 36, `CJK truncated body width ${vw(body)} should fit budget=36`);
+    } finally {
+      cleanCommentCache();
+    }
+  });
+
+  it('long emoji comment is truncated at visual-cell budget', () => {
+    cleanCommentCache();
+    try {
+      // 🎉 = U+1F389 (Emoji pictograph, range 0x1F300-0x1F9FF, width 2).
+      // 30 emoji = 60 cells; budget 36 => must be cut.
+      const longComment = '🎉'.repeat(30);
+      const { body } = renderCachedComment(longComment);
+      assert.ok(body.endsWith('…'), `should end with ellipsis: ${JSON.stringify(body)}`);
+      assert.ok(vw(body) <= 36, `emoji truncated body width ${vw(body)} should fit budget=36`);
+    } finally {
+      cleanCommentCache();
+    }
+  });
+
+  it('comment fitting within budget is passed through unchanged (no ellipsis)', () => {
+    cleanCommentCache();
+    try {
+      // 10 hiragana = 20 cells, fits comfortably in budget=36.
+      const shortComment = 'おつかれさまです！';
+      const { body } = renderCachedComment(shortComment);
+      assert.ok(!body.endsWith('…'), `should not append ellipsis when within budget: ${JSON.stringify(body)}`);
+      assert.ok(body.startsWith(shortComment), `should keep full text: got ${JSON.stringify(body)}`);
     } finally {
       cleanCommentCache();
     }


### PR DESCRIPTION
colleague comment の 3 行目で日本語が文字の途中で切れていた問題を修正。

## 症状

```
💬 冴さん、147行追加されてるけど237行も削除されてるから、結構スッキリした内容になってるんでしょ～ 🧹✨ 10時間超の濃いセッションだったから、あとはレビュ
                                                                                                                                  ↑ ここで不自然に切断
```

## 原因

- 生成時 sanitize: `.slice(0, 80)` (UTF-16 code units) で日本語の途中を切ってた
- 表示時 sanitize: `truncStr` が `String.prototype.length` ベースで、CJK/絵文字の実際のセル幅と乖離してターミナル幅をはみ出してた

## 修正

| 変更 | 内容 |
|---|---|
| 生成時 cap | `.slice(0, 80)` → `[...raw].slice(0, 200).join('')` (surrogate-pair safe、200 codepoints) |
| `visualWidth` 新規 | CJK / Hiragana / Katakana / Hangul / fullwidth / 絵文字 = 2 cells、その他 = 1 cell |
| `truncStrVisual` 新規 | visual-cell ベースで切る。**comment 行専用** |
| `truncStr` | char-based のまま維持 (path/model/branch の column layout 用) |

### `truncStr` を分割した理由 (リグレッション回避)

途中で `truncStr` 全体を visual-cell 化していたんだけど、qa-simplify が **`/tmp/プロジェクト` のような非ASCII cwd で勝手に `/tmp/プロジェ…` に切られるリグレッション** を発見。`rawCol1` / `padEnd` が `.length` ベースで計算しているので、`truncStr` だけ visual-width 化するとレイアウト計算と desync する。最終的に **2 つの関数に分けて呼び分け** る形に落ち着けた。

## 検証

- `npm test`: **36/36 パス** (5 ケース新規追加)
- `npm run lint`: クリーン
- スモークテスト 2 件:
  - 非ASCII cwd `/tmp/プロジェクト` が full 表示される
  - 長い日本語コメントが `内容…` で省略される (visual width 境界)

## 結果プレビュー

```
Before: 💬 ...結構スッキリした内容になってるんでしょ～ 🧹✨ 10時間超の濃いセッションだったから、あとはレビュ
After:  💬 ...結構スッキリした内容…
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)